### PR TITLE
Pass all arguments to replace function

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function (replaceFrom, replaceTo, userOptions) {
 
     var _replaceTo = function (replacement) {
       if (typeof replaceTo === 'function') {
-        var replaceFunctionResult = replaceTo.call(replaceTo, replacement);
+        var replaceFunctionResult = replaceTo.apply(replaceTo, arguments);
 
         log(true, replacement, replaceFunctionResult, fileName);
 


### PR DESCRIPTION
Replace function gets only first argument but all matched groups, match offset and original content are not passed.