### PR TITLE
🐞 stream replace was buggy, fixes ReferenceError: search is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function (replaceFrom, replaceTo, userOptions) {
     };
 
     if (file.isStream()) {
-      file.contents = file.contents.pipe(rs(search, replacement));
+      file.contents = file.contents.pipe(rs(replaceFrom, _replaceTo));
       return callback(null, file);
     }
 


### PR DESCRIPTION
The current npm package raises an error when a file tree is used (glob, e.g. src/**/*). My updated fixed the code.

```
ReferenceError: search is not defined
    at DestroyableTransform._transform (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/gulp-string-replace/index.js:61:45)
    at DestroyableTransform.Transform._read (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/readable-stream/lib/_stream_transform.js:172:83)
    at doWrite (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/readable-stream/lib/_stream_writable.js:417:5)
    at DestroyableTransform.Writable.write (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/readable-stream/lib/_stream_writable.js:334:11)
    at write (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/Applications/MAMP/htdocs/customers/hima/achima-3d-cube-electron/node_modules/vinyl-fs/node_modules/readable-stream/lib/_stream_readable.js:664:5)
    at DestroyableTransform.emit (events.js:182:13)
```